### PR TITLE
host/guest type mismatch

### DIFF
--- a/calculator/src/lib.rs
+++ b/calculator/src/lib.rs
@@ -2,12 +2,17 @@
 mod bindings;
 
 use bindings::docs::adder::add::add;
-use bindings::exports::docs::calculator::calculate::{Guest, Op};
+use bindings::exports::docs::calculator::calculate::{Guest, Op, GuestHandle, Handle};
 use bindings::docs::calculator::res::Res;
 
 struct Component;
 
+struct H;
+impl GuestHandle for H {}
+
 impl Guest for Component {
+    type Handle = H;
+    fn test(_x: Handle) {}
     fn eval_expression(op: Op, x: u32, y: u32) -> u32 {
         let res = Res::new();
         res.write(x);

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -32,6 +32,11 @@ impl bindings::docs::adder::add::Host for Logger {
 pub struct Set(BTreeSet<u32>);
 
 impl bindings::docs::calculator::res::Host for Logger {}
+impl bindings::docs::calculator::res::HostHandle for Logger {
+    fn drop(&mut self, _res: Resource<bindings::docs::calculator::res::Handle>) -> Result<()> {
+        Ok(())
+    }
+}
 impl bindings::docs::calculator::res::HostRes for Logger {
     fn new(&mut self) -> Resource<Res> {
         let id = self.resource_table.push(Set(BTreeSet::default())).unwrap();
@@ -70,7 +75,7 @@ fn main() -> anyhow::Result<()> {
     };
     let mut store = Store::new(&engine, state);
 
-    let component = Component::from_file(&engine, "../target/wasm32-wasip1/debug/composed.wasm")?;
+    let component = Component::from_file(&engine, "../target/wasm32-wasip1/debug/calculator.wasm")?;
     let bindings = bindings::Logger::instantiate(&mut store, &component, &linker)?;
     use bindings::exports::docs::calculator::calculate::Op;
     bindings.docs_calculator_calculate().call_eval_expression(&mut store, Op::Add, 3, 4)?;

--- a/replay/wit/deps/calculator/calculator.wit
+++ b/replay/wit/deps/calculator/calculator.wit
@@ -6,13 +6,16 @@ interface res {
     write: func(x: u32);
     read: static func(x: res) -> res;
   }
+  resource handle;
 }
 
 interface calculate {
+  use res.{handle};
   enum op {
     add,
   }
 
   eval-expression: func(op: op, x: u32, y: u32) -> u32;
+  test: func(x: handle);
 }
 

--- a/wit/calculator/world.wit
+++ b/wit/calculator/world.wit
@@ -9,10 +9,12 @@ interface res {
 }
 
 interface calculate {
+    resource handle;
     enum op {
         add,
     }
     eval-expression: func(op: op, x: u32, y: u32) -> u32;
+    test: func(x: handle);
 }
 
 world calculator {


### PR DESCRIPTION
The `handle` type is structurally the same, but wasmtime cannot instantiate the module.